### PR TITLE
C64: Optimize ilog2 using bit twiddling hack

### DIFF
--- a/common.h
+++ b/common.h
@@ -15,12 +15,18 @@
 /* Ensure that __builtin_clz is never called with 0 argument */
 static inline int ilog2(uint32_t x)
 {
-    // FIXME: likely inefficient (but also rarely used...)
 #if C64
-    uint8_t lz=0;
-    while(x>>=1)
-	lz++;
-    return lz;
+    static const int table[32] = {0,  9,  1,  10, 13, 21, 2,  29, 11, 14, 16,
+                                  18, 22, 25, 3,  30, 8,  12, 20, 28, 15, 17,
+                                  24, 7,  19, 27, 23, 6,  26, 5,  4,  31};
+
+    x |= x >> 1;
+    x |= x >> 2;
+    x |= x >> 4;
+    x |= x >> 8;
+    x |= x >> 16;
+
+    return table[(uint32_t) (x * 0x07C4ACDDU) >> 27];
 #else
     return 31 - __builtin_clz(x | 1);
 #endif


### PR DESCRIPTION
I conducted a micro-benchmark[1] testing the efficiency of inputs ranging from 1 to 10,000,000, and observed a significant improvement, validating the effectiveness of the implemented optimization. Additionally, I validated the correctness of the optimization by running a unit test[2] loop over all values from 1 to 0xffffffff as input and comparing the results with the expression ```31 - __builtin_clz(x | 1)```. The comprehensive test ensures the accuracy of the implemented optimization.

[1]:
```
/*
 * Benchmark the performance of ilog2 and ilog2_old.
 * Time of new ilog2: 71
 * Time of old ilog2: 359
*/
void benchmark()
{
    const int loop = 10000000;
    long long int t_old, t_new;

    t_new = clock();
    for(uint32_t i = 1; i < loop; i++) {
        int y = ilog2(i);
    }
    t_new = clock() - t_new;

    t_old = clock();
    for(uint32_t i = 1; i < loop; i++) {
        int y = ilog2_old(i);
    }
    t_old = clock() - t_old;

    printf("Time of new ilog2: %lld\n", t_new);
    printf("Time of old ilog2: %lld\n", t_old);
}
```
[2]:
```
/* Return 0 on success and return 1 on failure. */
int unit_test()
{
    uint32_t x = 1;
    while(1) {
        int y = ilog2(x);
        int z = 31 - __builtin_clz(x | 1);
        if(y != z) return 1;
        if(x == 0xffffffff) break;
        x++;
    }
    return 0;
}
```
